### PR TITLE
FEATURE: Make base_uri value configurable at initialization

### DIFF
--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -86,6 +86,19 @@ describe ApiWrapperFor8x8::Connection do
         ApiWrapperFor8x8::Connection::base_uri.should_not be_nil
         ApiWrapperFor8x8::Connection::base_uri.size.should_not be_zero
       end
+
+      it "should resemble a Contactual/8x8 API address" do
+        "https://naX.mycontactual.com/api".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should_not be_nil
+        "http://vcc-naX.8x8.com/api".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should_not be_nil
+        "https://vcc-naX.8x8.com/api".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should_not be_nil
+        "https://vcc-naX.not8x8.com/api".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should be_nil
+        "https://naX.notmycontactual.com/api".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should be_nil
+        "vcc-naX.8x8.com/api".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should be_nil
+        "https://www.someother.com/api".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should be_nil
+        "ftp://vcc-naX.8x8.com/api".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should be_nil
+        "http://vcc-naX.8x8.com/".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should be_nil
+        "https://vcc-naX.8x8.com".match(ApiWrapperFor8x8::Connection::API_URI_REGEX).should be_nil
+      end
     end
 
   end


### PR DESCRIPTION
While attempting to use this gem for integrating our own SaaS product with the 8x8 system, I found the base_uri value to be hard-coded to a value different to that provided by our points of contact at 8x8.  This pull request expands `Connection#initialize` to:
- Decouple that base value from the code itself
- Accept an optional argument that serves as the `base_uri` for all API calls
- Use the originally hard-coded value if none is given.

This change should not effect any legacy users of this gem; while the interface for `Connection#initialize` has technically changed, it has been done with the intent of maintaining functionality for any code base built around its previous incarnation.

There is some restriction to what values will be accepted as the optional `base_uri`.  Regex is used to insure the provided value appears to be a fully-qualified address, and points to either an 8x8 or MyContactual domain name. Rspec coverage has been expanded to confirm the user-provided URI is being appropriately vetted to meet these requirements.

> Note: At the time of opening this pull request, I observed two failing Rspec examples.  While I have added a spec for this new functionality, and insured its passing, I have not attempted to resolve the existing Rspec failures.  I think that would be better handled in its own discrete commit.
